### PR TITLE
perf(workspace): add index for default workspace lookup

### DIFF
--- a/Migrations/2026_02_01_000001_add_user_workspace_default_index.php
+++ b/Migrations/2026_02_01_000001_add_user_workspace_default_index.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Add composite index for default workspace lookup.
+     *
+     * The User::defaultHostWorkspace() method queries by user_id and is_default
+     * on every authenticated request needing workspace context. This index
+     * optimises that common query pattern.
+     */
+    public function up(): void
+    {
+        Schema::table('user_workspace', function (Blueprint $table) {
+            $table->index(['user_id', 'is_default'], 'user_workspace_user_default_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('user_workspace', function (Blueprint $table) {
+            $table->dropIndex('user_workspace_user_default_idx');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
Adds missing composite index on `user_workspace` table for default workspace queries.

## Problem
`User::defaultHostWorkspace()` queries `WHERE user_id = ? AND is_default = true` on every authenticated request needing workspace context, but no index existed for this pattern.

## Solution
Added composite index `(user_id, is_default)` to optimise this common query.

## Test Plan
- [ ] CI passes
- [ ] Migration runs successfully
- [ ] Default workspace queries use index (EXPLAIN shows index scan)

Closes #15

---
Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized database queries for workspace context resolution to improve request handling efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->