### PR TITLE
fix(webhook): add DNS rebinding defence to dispatch job

### DIFF
--- a/Jobs/DispatchEntitlementWebhook.php
+++ b/Jobs/DispatchEntitlementWebhook.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Core\Tenant\Jobs;
 
+use Core\Tenant\Concerns\PreventsSSRF;
 use Core\Tenant\Enums\WebhookDeliveryStatus;
 use Core\Tenant\Models\EntitlementWebhook;
 use Illuminate\Bus\Queueable;
@@ -22,7 +23,7 @@ use Illuminate\Support\Str;
  */
 class DispatchEntitlementWebhook implements ShouldQueue
 {
-    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+    use Dispatchable, InteractsWithQueue, PreventsSSRF, Queueable, SerializesModels;
 
     /**
      * The number of times the job may be attempted.
@@ -67,6 +68,37 @@ class DispatchEntitlementWebhook implements ShouldQueue
                 'event' => $this->eventName,
             ]);
 
+            return;
+        }
+
+        // Validate URL for SSRF before making request (DNS rebinding protection)
+        $ssrfValidation = $this->validateUrlForSSRF($webhook->url);
+        if (! $ssrfValidation['valid']) {
+            Log::warning('Entitlement webhook blocked due to SSRF validation failure', [
+                'webhook_id' => $this->webhookId,
+                'event' => $this->eventName,
+                'url' => $webhook->url,
+                'reason' => $ssrfValidation['error'],
+            ]);
+
+            // Record the failed delivery - do not retry SSRF violations
+            $webhook->deliveries()->create([
+                'uuid' => Str::uuid(),
+                'event' => $this->eventName,
+                'attempts' => $this->attempts(),
+                'status' => WebhookDeliveryStatus::FAILED,
+                'payload' => [
+                    'event' => $this->eventName,
+                    'data' => $this->eventPayload,
+                ],
+                'response' => ['error' => 'SSRF validation failed: '.$ssrfValidation['error']],
+                'created_at' => now(),
+            ]);
+
+            $webhook->incrementFailureCount();
+            $webhook->updateLastDeliveryStatus(WebhookDeliveryStatus::FAILED);
+
+            // Do not throw - SSRF violations should not be retried
             return;
         }
 


### PR DESCRIPTION
## Summary
- Add SSRF validation before HTTP request in `DispatchEntitlementWebhook` job
- Use existing `PreventsSSRF` trait to validate URLs at request time
- Block and log requests to private/local addresses without retrying

## Problem
The `DispatchEntitlementWebhook` job made HTTP requests without SSRF validation. While URLs were validated at registration time, several attack vectors remained:
1. **DNS rebinding**: Attacker registers webhook with a domain they control, then changes DNS to point to internal IP
2. **URL mutation**: If webhook URL is updated directly in database (admin tools, API, etc.)
3. **Time-of-check to time-of-use (TOCTOU)**: URL valid at registration but changes before job executes

## Solution
Validate the URL using `validateUrlForSSRF()` from the `PreventsSSRF` trait immediately before making the HTTP request. This resolves the hostname and validates all resolved IPs are not private/local.

SSRF violations are:
- Logged with full context (webhook ID, event, URL, reason)
- Recorded as failed deliveries in the database
- Not retried (no exception thrown) since they indicate malicious intent

## Test plan
- [ ] Verify webhook delivery still works for valid external URLs
- [ ] Verify webhooks to localhost/private IPs are blocked
- [ ] Verify DNS rebinding attack is prevented (domain resolving to internal IP)
- [ ] Verify failure is logged and recorded without retry

Closes #6

---
Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added webhook URL validation that runs before delivery attempts. Invalid URLs are now caught, logged, and marked as failed deliveries with detailed error information. This improves webhook reliability tracking and prevents unnecessary requests to invalid endpoints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->